### PR TITLE
Enable pagination with sorting

### DIFF
--- a/src/routes/transaction.ts
+++ b/src/routes/transaction.ts
@@ -2,25 +2,59 @@
 
 import express from 'express';
 import { Transaction } from '../model';
+import { sequelize } from '../db';
+import { QueryTypes } from 'sequelize';
 
 const router = express.Router();
 
-router.get('/', async (req, res, next) => {
+router.get('/:organization_id/:year/:half', async (req, res, next) => {
     try {
         const page = parseInt(req.query.page as string);
         const limit = 20;
         const startIndex = (page - 1) * limit;
         const endIndex = page * limit;
-        const transactions = await Transaction.findAll();
-        const sortedTransaction = transactions.sort((a, b) => {
-            return a.transactionAt.getTime() - b.transactionAt.getTime();
-        });
-        const transaction1page = sortedTransaction.slice(startIndex, endIndex);
-        res.json(
-            transaction1page.map((transaction1page) =>
-                transaction1page.toJSON(),
-            ),
+
+        const schema_name = process.env.NODE_ENV || 'development';
+        const transaction_table = schema_name + '."transactions"';
+        const income_table = schema_name + '."incomes"';
+        const expense_table = schema_name + '."expenses"';
+        const budget_table = schema_name + '."budgets"';
+        const transactions = await sequelize.query(
+            `SELECT *
+            FROM
+                (
+                    SELECT T."id", T."projectAt", T."manager", T."content", T."type", T."amount", T."transactionAt", T."accountNumber", T."accountBank", T."accountOwner", T."hasBill", T."note", T."IncomeId", T."ExpenseId", I."code"
+                    FROM ${income_table} AS I 
+                        INNER JOIN ${transaction_table} AS T
+                        ON I.id = T."IncomeId"
+                    WHERE I."BudgetId" IN (
+                        SELECT id
+                        FROM ${budget_table}
+                        WHERE "OrganizationId" = ${req.params.organization_id}
+                            AND "year" = '${req.params.year}' AND "half" = '${req.params.half}'
+                    )
+                ) as TIE
+                UNION ALL
+                (
+                    SELECT T."id", T."projectAt", T."manager", T."content", T."type", T."amount", T."transactionAt", T."accountNumber", T."accountBank", T."accountOwner", T."hasBill", T."note", T."IncomeId", T."ExpenseId", E."code"
+                    FROM ${expense_table} AS E
+                        INNER JOIN ${transaction_table} AS T
+                        ON E.id = T."ExpenseId"
+                    WHERE "BudgetId" IN (
+                        SELECT id
+                        FROM ${budget_table}
+                        WHERE "OrganizationId" = ${req.params.organization_id}
+                            AND "year" = '${req.params.year}' AND "half" = '${req.params.half}'
+                    )
+                )
+            ORDER BY "transactionAt" DESC`,
+            {
+                type: QueryTypes.SELECT,
+            },
         );
+
+        const transaction1page = transactions.slice(startIndex, endIndex);
+        res.json(transaction1page);
     } catch (error) {
         next(error);
     }

--- a/src/routes/transaction.ts
+++ b/src/routes/transaction.ts
@@ -7,8 +7,20 @@ const router = express.Router();
 
 router.get('/', async (req, res, next) => {
     try {
+        const page = parseInt(req.query.page as string);
+        const limit = 20;
+        const startIndex = (page - 1) * limit;
+        const endIndex = page * limit;
         const transactions = await Transaction.findAll();
-        res.json(transactions.map((transaction) => transaction.toJSON()));
+        const sortedTransaction = transactions.sort((a, b) => {
+            return a.transactionAt.getTime() - b.transactionAt.getTime();
+        });
+        const transaction1page = sortedTransaction.slice(startIndex, endIndex);
+        res.json(
+            transaction1page.map((transaction1page) =>
+                transaction1page.toJSON(),
+            ),
+        );
     } catch (error) {
         next(error);
     }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -907,6 +907,33 @@ paths:
         get:
             summary: 모든 통장거래내역 조회
             tags: [통장거래내역]
+            parameters:
+                - name: organization_id
+                  in: path
+                  description: 피감기구 id
+                  required: true
+                  schema:
+                      type: integer
+                      format: int32
+                      example: 1
+                - name: year
+                  in: path
+                  description: 연도
+                  required: true
+                  schema:
+                      type: integer
+                      format: int32
+                      example: 2023
+                - name: half
+                  in: path
+                  description: 반기
+                  required: true
+                  schema:
+                      type: string
+                      enum:
+                          - spring
+                          - fall
+                      example: spring
             responses:
                 '200':
                     description: Successfully retrieved transactions

--- a/test/routes/transaction.spec.ts
+++ b/test/routes/transaction.spec.ts
@@ -1,0 +1,74 @@
+import chaiHttp from 'chai-http';
+import app from '../../src/app';
+import chai, { expect } from 'chai';
+import { initDB } from '../../src/db/util';
+import sinon from 'sinon';
+import { Budget, Income, Organization, Transaction } from '../../src/model';
+
+chai.use(chaiHttp);
+
+describe('transaction router', () => {
+    before(async function () {
+        await initDB();
+    });
+
+    describe('GET /', () => {
+        it('should return all transactions', async () => {
+            const organization = await Organization.create({
+                name: '학부총학생회',
+            });
+
+            const budget = await Budget.create({
+                year: 2021,
+                half: 'spring',
+                manager: '김넙죽',
+                OrganizationId: organization.id,
+            });
+
+            const income = await Income.create({
+                code: '101',
+                source: '학생회비',
+                category: '중앙회계',
+                content: '예산',
+                amount: 10000,
+                BudgetId: budget.id,
+            });
+
+            const dates = [];
+            const t = new Date('2021-01-01:00:00:00');
+            for (var i = 0; i < 30; i++) {
+                t.setDate(t.getDate() + 1);
+                dates.push(new Date(t));
+                await Transaction.create({
+                    projectAt: t,
+                    manager: '김넙죽',
+                    content: '테스트',
+                    type: '공금카드',
+                    amount: 10000,
+                    transactionAt: t,
+                    accountNumber: '1234567890',
+                    accountBank: '우리은행',
+                    accountOwner: '김넙죽',
+                    hasBill: false,
+                    IncomeId: income.id,
+                });
+            }
+
+            const expected_dates = dates
+                .sort((a, b) => b.getTime() - a.getTime())
+                .map((date) => date.toISOString())
+                .slice(20, 30);
+
+            const res = await chai
+                .request(app)
+                .get(`/transactions/${organization.id}/2021/spring?page=2`);
+            expect(res).to.have.status(200);
+            expect(res.body).to.be.an('array');
+
+            const actual_dates = res.body.map(
+                (transaction: any) => transaction.transactionAt,
+            );
+            expect(actual_dates).eql(expected_dates);
+        });
+    });
+});


### PR DESCRIPTION
현재까지 구현된 pagination과 sorting feature 완료해서 PR 올립니다...!

기본적으로는 routes 폴더 내 transaction.ts에서 주소에 page 값을 받아오면 거래일 기준으로 sort된 거래내역(`sortedTransaction`) 중 받아온 page 값에 해당되는 내역들만 slice(`transaction1page`)하는 형식입니다!
화면에서 page 번호들을 쭉 띄우고 클릭하면 이동하는 방식은 프론트와의 연결이 필요할 것 같습니다.